### PR TITLE
Track cpu microarchitecture

### DIFF
--- a/html/commit.js
+++ b/html/commit.js
@@ -83,15 +83,28 @@ async function renderTable() {
   stepTitle.textContent = `${job} steps`;
   titles.appendChild(stepTitle);
 
+  const cpuMicroarchs = document.createElement('tr');
+  table.appendChild(cpuMicroarchs);
+  const cpuMicroarchsTitle = document.createElement('td');
+  cpuMicroarchsTitle.textContent = 'CPU microarchitecture';
+  cpuMicroarchs.appendChild(cpuMicroarchsTitle);
+
   for (let item of order) {
     if (item.commit === undefined)
       continue;
+    let microarch = item.commit.jobs[job].cpu_microarch;
+    if (microarch === null)
+      microarch = 'unknown';
+    const microarchCell = document.createElement('td');
+    microarchCell.textContent = microarch;
+    cpuMicroarchs.appendChild(microarchCell);
     for (let step in item.commit.jobs[job].timings) {
       if (step in stepSet)
         continue;
 
       const add = step => {
         const row = document.createElement('tr');
+        row.classList.add('sortable');
         table.appendChild(row);
         const name = document.createElement('td');
         name.textContent = prettyStep(step);
@@ -271,7 +284,7 @@ function sortTable() {
     sorts[sortCol].textContent = "⬆";
 
   const rows = [];
-  for (let row of table.querySelectorAll('tr:not(:first-child)')) {
+  for (let row of table.querySelectorAll('tr.sortable')) {
     row.remove();
     rows.push(row);
   }

--- a/html/index.js
+++ b/html/index.js
@@ -65,9 +65,12 @@ async function run() {
       },
       headerFormat: '<b>{series.name}</b><br>',
       pointFormatter: function() {
-        let text = '' + format(this.y);
+        let text = '<small>length:</small> ' + format(this.y);
         const commit = data.commits[this.index].sha;
-        text += '<br>' + commit.substring(0, 8);
+        text += '<br><small>sha:</small> ' + commit.substring(0, 8);
+        const microarch = data.commits[this.index].jobs[this.series.name].cpu_microarch;
+        if (microarch !== null)
+          text += '<br><small>cpu:</small> ' + microarch;
         return text;
       },
     },

--- a/src/bin/build-site.rs
+++ b/src/bin/build-site.rs
@@ -46,6 +46,9 @@ fn main() {
 fn run(args: &Args) -> Result<(), Error> {
     let commits = get_commits(&args.arg_rust_repo, &args.arg_cache_dir)?;
 
+    if !args.arg_out_dir.exists() {
+        std::fs::create_dir_all(&args.arg_out_dir)?;
+    }
     write_overall(&commits, &args.arg_out_dir)?;
     write_each_commit(&commits, &args.arg_out_dir)?;
     Ok(())

--- a/src/bin/build-site.rs
+++ b/src/bin/build-site.rs
@@ -143,8 +143,8 @@ fn get_commits(rust: &Path, cache: &Path) -> Result<Vec<(GitCommit, Commit)>, Er
         if !path.exists() {
             let url = format!(
                 "https://s3-{}.amazonaws.com/{}/commits/{}.json.gz",
-                env::var("S3_REGION").unwrap(),
-                env::var("S3_BUCKET").unwrap(),
+                env::var("S3_REGION").expect("missing environment variable S3_REGION"),
+                env::var("S3_BUCKET").expect("missing environment variable S3_BUCKET"),
                 commit.sha
             );
             urls.push(url);

--- a/src/bin/publish-data-to-s3.rs
+++ b/src/bin/publish-data-to-s3.rs
@@ -315,8 +315,8 @@ impl Context {
     }
 
     fn curl_s3(&self) -> Curl {
-        let region = env::var("S3_REGION").unwrap();
-        let bucket = env::var("S3_BUCKET").unwrap();
+        let region = env::var("S3_REGION").expect("missing environment variable S3_REGION");
+        let bucket = env::var("S3_BUCKET").expect("missing environment variable S3_BUCKET");
         self.curl(&format!("https://s3-{}.amazonaws.com/{}", region, bucket))
     }
 }

--- a/src/bin/publish-data-to-s3.rs
+++ b/src/bin/publish-data-to-s3.rs
@@ -1,12 +1,12 @@
 use failure::{bail, format_err, Error, ResultExt};
 use rayon::prelude::*;
+use shared::{Commit, Job, Timing};
 use std::collections::{BTreeMap, HashMap};
 use std::env;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{self, Command, Stdio};
-use shared::{Timing, Job, Commit};
 
 struct Context {
     appveyor: HashMap<String, appveyor::Build>,
@@ -105,6 +105,7 @@ impl Context {
                 Job {
                     url: log.job_url.clone(),
                     path: log.path.clone(),
+                    cpu_microarch: self.extract_cpu_microarch(&log.contents),
                     timings: self.extract_timings(&log.contents),
                 },
             );
@@ -123,19 +124,14 @@ impl Context {
         let mut parts = HashMap::new();
         for line in contents.lines() {
             let line = line.trim();
-            let needle1 = "[TIMING] ";
-            let needle2 = "[RUSTC-TIMING] ";
-
-            if let Some(pos) = line.find(needle2) {
-                let rest = &line[pos + needle2.len()..];
+            if let Some(rest) = find_get_after(line, "[RUSTC-TIMING] ") {
                 let mut iter = rest.rsplitn(2, ' ');
                 let time = iter.next().unwrap().parse::<f64>().unwrap();
                 let name = iter.next().unwrap();
                 *parts.entry(name.to_string()).or_insert(0.0) += time;
             }
 
-            if let Some(pos) = line.find(needle1) {
-                let rest = &line[pos + needle1.len()..];
+            if let Some(rest) = find_get_after(line, "[TIMING] ") {
                 let pos = rest.find(" -- ").unwrap();
                 let step = &rest[..pos];
                 let dur = rest[pos + 4..].parse::<f64>().unwrap();
@@ -147,6 +143,29 @@ impl Context {
             }
         }
         return ret;
+    }
+
+    fn extract_cpu_microarch(&self, contents: &str) -> Option<String> {
+        let mut family = None;
+        for line in contents.lines() {
+            let line = line.trim();
+            match family {
+                None => {
+                    if let Some(family_content) = find_get_after(line, "cpu family\t: ") {
+                        family = Some(family_content);
+                    }
+                }
+                Some(family) => {
+                    if let Some(model) = find_get_after(line, "model\t\t: ") {
+                        return INTEL_CPU_MODEL_TO_MICROARCH
+                            .iter()
+                            .find(|(f, m, _)| *f == family && *m == model)
+                            .map(|(_, _, arch)| arch.to_string());
+                    }
+                }
+            }
+        }
+        None
     }
 
     fn identify_job(&self, log: &Log) -> Result<String, Error> {
@@ -372,6 +391,23 @@ impl Curl {
         }
     }
 }
+
+fn find_get_after<'a>(content: &'a str, needle: &str) -> Option<&'a str> {
+    content
+        .find(needle)
+        .map(|pos| &content[pos + needle.len()..])
+}
+
+/// Map the CPU family and model to the microarchitecture name
+/// Source for the data: https://en.wikichip.org/wiki/intel/cpuid
+static INTEL_CPU_MODEL_TO_MICROARCH: &[(&str, &str, &str)] = &[
+    ("6", "45", "sandybridge"),
+    ("6", "62", "ivybridge"),
+    ("6", "63", "haswell"),
+    ("6", "79", "broadwell"),
+    ("6", "85", "skylake"),
+    ("6", "86", "broadwell"),
+];
 
 #[allow(dead_code)]
 mod travis {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub struct Commit {
 pub struct Job {
     pub url: String,
     pub path: String,
+    pub cpu_microarch: Option<String>,
     pub timings: BTreeMap<String, Timing>,
 }
 
@@ -27,7 +28,9 @@ pub struct GitCommit {
     pub date: String,
 }
 
-pub fn get_git_commits(repo: &Path) -> Result<impl Iterator<Item = Result<GitCommit, Error>>, Error> {
+pub fn get_git_commits(
+    repo: &Path,
+) -> Result<impl Iterator<Item = Result<GitCommit, Error>>, Error> {
     let mut child = Command::new("git")
         .arg("log")
         .arg("--author=bors")


### PR DESCRIPTION
This PR tracks the currently used CPU microarchitecture by reading `/proc/cpuinfo`, and shows the data both in the index's graph tooltips and in the detailed table as its own row.

The data is fetched from Windows and Linux, but there is no point in loading macOS since we always run on the same dedicated machines. Before this is merged the S3 will need to be wiped, since the PR adds a new field to the resulting JSONs.

![2019-03-28--10-48-34](https://user-images.githubusercontent.com/2299951/55147795-55788380-5147-11e9-9648-0f655c02751b.png)
![2019-03-28--10-49-35](https://user-images.githubusercontent.com/2299951/55147796-55788380-5147-11e9-9c75-dc4e2f8e9639.png)
